### PR TITLE
Added --service-account-subject

### DIFF
--- a/auth/oauth.go
+++ b/auth/oauth.go
@@ -65,7 +65,7 @@ func NewAccessTokenClient(clientId, clientSecret, accessToken string) *http.Clie
 	)
 }
 
-func NewServiceAccountClient(serviceAccountFile string) (*http.Client, error) {
+func NewServiceAccountClient(serviceAccountFile string, serviceAccountSubject string) (*http.Client, error) {
 	content, exists, err := ReadFile(serviceAccountFile)
 	if(!exists) {
 		return nil, fmt.Errorf("Service account filename %q not found", serviceAccountFile)
@@ -79,6 +79,11 @@ func NewServiceAccountClient(serviceAccountFile string) (*http.Client, error) {
 	if(err != nil) {
 		return nil, err
 	}
+
+	if (serviceAccountSubject != "") {
+		conf.Subject = serviceAccountSubject
+	}
+
 	return conf.Client(oauth2.NoContext), nil
 }
 

--- a/gdrive.go
+++ b/gdrive.go
@@ -45,6 +45,11 @@ func main() {
 			Patterns:    []string{"--service-account"},
 			Description: "Oauth service account filename, used for server to server communication without user interaction (filename path is relative to config dir)",
 		},
+		cli.StringFlag{
+			Name:        "serviceAccountSubject",
+			Patterns:    []string{"--service-account-subject"},
+			Description: "Connect to this user account GDrive instead of the service account GDrive. Useful only with the --service-account parameter. The service account must be domain-wide delegated.",
+		},
 	}
 
 	handlers := []*cli.Handler{

--- a/handlers_drive.go
+++ b/handlers_drive.go
@@ -357,7 +357,7 @@ func getOauthClient(args cli.Arguments) (*http.Client, error) {
 
 	if args.String("serviceAccount") != "" {
 		serviceAccountPath := ConfigFilePath(configDir, args.String("serviceAccount"))
-		serviceAccountClient, err := auth.NewServiceAccountClient(serviceAccountPath)
+		serviceAccountClient, err := auth.NewServiceAccountClient(serviceAccountPath, args.String("serviceAccountSubject"))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
You can use this option when connecting using --service-account. Filling
the Google account username into --service-account-subject you will be
connected as this Google account instead of the service account.

Required settings on the Google site:
1. Service account must be domain-wide delegated (Google APIs > IAM & Admin
> Service accounts > Edit service account > check "Enable GSuite
Domain-wide Delegation". Also new OAuth 2.0 client will be created.
2. There must be allowed SDK API in the GDrive settings (Admin Console >
Apps > GSuite > Drive and Docs > Data access > check "Allow Drive SDK
API"
3. The newly created OAuth 2.0 client must be allowed in the GSuite security
settings to use GDrive API (Admin Console > Security > Show more >
Advanced settings > click Manage API client access > fill the form:
- Client ID is the client id found in Google APIs > APIs & Services >
Credentials
- One or more API Scopes is "https://www.googleapis.com/auth/drive"